### PR TITLE
feat: Add pcap reader breakloop method to break from reader's loop

### DIFF
--- a/pcapobj.cc
+++ b/pcapobj.cc
@@ -68,6 +68,7 @@ static PyObject* p_setfilter( pcapobject* pp, PyObject* args );
 static PyObject* p_next(pcapobject* pp, PyObject*);
 static PyObject* p_dispatch(pcapobject* pp, PyObject* args);
 static PyObject* p_loop(pcapobject* pp, PyObject* args);
+static PyObject* p_breakloop(pcapobject* pp, PyObject* args);
 static PyObject* p_datalink(pcapobject* pp, PyObject* args);
 static PyObject* p_setdirection(pcapobject* pp, PyObject* args);
 static PyObject* p_setnonblock(pcapobject* pp, PyObject* args);
@@ -86,6 +87,7 @@ static PyObject* p_activate(pcapobject* pp, PyObject* args);
 
 static PyMethodDef p_methods[] = {
   {"loop", (PyCFunction) p_loop, METH_VARARGS, "loops packet dispatching"},
+  {"breakloop", (PyCFunction) p_breakloop, METH_NOARGS, "break the loop for packet dispatching"},
   {"dispatch", (PyCFunction) p_dispatch, METH_VARARGS, "dispatchs packets"},
   {"next", (PyCFunction) p_next, METH_NOARGS, "returns next packet"},
   {"setfilter", (PyCFunction) p_setfilter, METH_VARARGS, "compiles and sets a BPF capture filter"},
@@ -549,11 +551,30 @@ p_loop(pcapobject* pp, PyObject* args)
   PyEval_RestoreThread(ctx.thread_state);
 
   if(ret<0) {
-    if (ret!=-2)
+    if (ret!=-2) {
       /* pcap error, pcap_breakloop was not called so error is not set */
       PyErr_SetString(PcapError, pcap_geterr(pp->pcap));
-    return NULL;
+      return NULL;
+    }
   }
+
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
+static PyObject*
+p_breakloop(pcapobject* pp, PyObject*)
+{
+  if (Py_TYPE(pp) != &Pcaptype)
+    {
+      PyErr_SetString(PcapError, "Not a pcap object");
+      return NULL;
+    }
+
+  if (!pp->pcap)
+    return err_closed();
+
+  pcap_breakloop(pp->pcap);
 
   Py_INCREF(Py_None);
   return Py_None;

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name=PACKAGE_NAME,
-      version="1.0.9",
+      version="1.1.0",
       url="https://github.com/stamparm/pcapy-ng/",
       author="Miroslav Stampar",
       author_email="miroslav@sqlmap.org",


### PR DESCRIPTION
Allow clean breaking from loop

```python
packets = pcapy.open_live(self._interface, max_packet_size, promiscuous, timeout)  # type: ignore
packets.setfilter("wlan type mgt")  # type: ignore
packets.loop(-1, packet_process)  # type: ignore

# another thread calls
packets.breakloop() # this returns from packets.loop
```